### PR TITLE
Release OGraf Studio 0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ building executables and verification.
 
 - [Using Studio](docs/USER_GUIDE.md) — projects, images, SVG and Lottie.
 - [AI authoring](docs/AI_AUTHORING.md) — built-in chat, MCP clients and the authoring skill.
-- [Release notes](docs/releases/0.16.md) — what's new in 0.16.
+- [Release notes](docs/releases/0.17.md) — what's new in 0.17.
 - [Contributing](CONTRIBUTING.md) — community development and verification.
 
 Automated OGraf conformance checks are not EBU certification or a guarantee of compatibility with

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ograf-editor/mcp-server",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "main": "src/index.ts",

--- a/apps/mcp-server/src/mcpServer.ts
+++ b/apps/mcp-server/src/mcpServer.ts
@@ -14,7 +14,7 @@ export function createOGrafMcpServer(
   workspace: AuthoringWorkspace,
   bridge: EditorBridge,
 ): McpServer {
-  const server = new McpServer({ name: 'ograf-editor', version: '0.16.0' });
+  const server = new McpServer({ name: 'ograf-editor', version: '0.17.0' });
   const registerTool = server.registerTool.bind(server) as unknown as RegisterTool;
   for (const tool of createOGrafToolRecords(workspace, bridge)) {
     registerTool(tool.name, tool.config, tool.handler);

--- a/apps/mcp-server/src/standaloneConfig.test.ts
+++ b/apps/mcp-server/src/standaloneConfig.test.ts
@@ -45,8 +45,8 @@ describe('standalone server configuration', () => {
   });
 
   it('includes the product version in standalone output', () => {
-    expect(OGRAF_STUDIO_STANDALONE_VERSION).toBe('0.16');
-    expect(STANDALONE_HELP).toContain('OGraf Studio 0.16 standalone server');
+    expect(OGRAF_STUDIO_STANDALONE_VERSION).toBe('0.17');
+    expect(STANDALONE_HELP).toContain('OGraf Studio 0.17 standalone server');
   });
 
   it('provides compact ASCII-only Zero Density and repository branding', () => {

--- a/apps/mcp-server/src/standaloneConfig.ts
+++ b/apps/mcp-server/src/standaloneConfig.ts
@@ -8,7 +8,7 @@ export interface StandaloneServerOptions {
   help: boolean;
 }
 
-export const OGRAF_STUDIO_STANDALONE_VERSION = '0.16';
+export const OGRAF_STUDIO_STANDALONE_VERSION = '0.17';
 export const OGRAF_STUDIO_REPOSITORY_URL = 'https://github.com/zerodensity/ograf-studio';
 const ZERO_DENSITY_OD_ASCII = [
   '   ##########      ##########',

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -100,7 +100,7 @@ self-contained.
 
 Linux users must make the downloaded file executable with `chmod +x`. The macOS artifacts are raw,
 unsigned command-line executables; they require code signing and notarization before broad external
-distribution. The Windows executable contains Zero Density product/version metadata and the OGS
+distribution. The Windows executable contains Zero Density product/version metadata and the official OGraf
 icon; headless macOS/Linux executables do not have desktop application icons.
 
 The source-level `npm run mcp:start` server also binds only to loopback, but defaults its writable

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -96,7 +96,7 @@ exported graphic in the intended playout environment.
 
 For vector points and handles, see the [path-editing guide](../skills/ograf-authoring/references/path-editing.md).
 Clicking blank canvas keeps path editing active. Choose **Done** or press **Escape** to finish.
-For recent changes, see the [release notes](releases/0.16.md).
+For recent changes, see the [release notes](releases/0.17.md).
 
 Manage a selected layer's data links under **Properties → Data Bindings**. Binding indicators are
 not drawn over the canvas artwork.

--- a/docs/generated/mcp-contracts.json
+++ b/docs/generated/mcp-contracts.json
@@ -1,6 +1,6 @@
 {
   "contractVersion": 1,
-  "server": { "name": "ograf-editor", "version": "0.16.0" },
+  "server": { "name": "ograf-editor", "version": "0.17.0" },
   "tools": [
     {
       "name": "ograf_get_capabilities",

--- a/docs/releases/0.17.md
+++ b/docs/releases/0.17.md
@@ -1,0 +1,20 @@
+# OGraf Studio 0.17
+
+Released: 2026-09-09
+
+This release introduces consistent official OGraf branding across Studio and its downloads.
+
+- Official OGraf wordmark in the top bar and export section, with a compact **Studio** label.
+- The official OGraf website icon replaces the browser and Windows executable icons.
+- The GitHub overview uses the official wordmark with light and dark theme support.
+- Bundled asset licensing and updated MCP version metadata.
+
+## Downloads
+
+Single-file servers are available for Windows x64, macOS Intel/Apple Silicon and Linux x64/ARM64.
+Run the executable and open http://127.0.0.1:4318/. No Node.js, npm or Bun installation is needed.
+On macOS/Linux, first run `chmod +x <downloaded-file>`.
+
+The release includes the authoring skill ZIP, SHA-256 checksums and a build manifest. Windows and
+macOS executables are unsigned; macOS builds are not notarized. macOS and ARM64 builds are
+cross-compiled and structurally verified; native execution on those platforms remains unverified.

--- a/docs/releases/0.17.md
+++ b/docs/releases/0.17.md
@@ -8,6 +8,7 @@ This release introduces consistent official OGraf branding across Studio and its
 - The official OGraf website icon replaces the browser and Windows executable icons.
 - The GitHub overview uses the official wordmark with light and dark theme support.
 - Bundled asset licensing and updated MCP version metadata.
+- Updated dependencies to address reported security advisories.
 
 ## Downloads
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zd-ograf-editor",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zd-ograf-editor",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "apps/*",
@@ -49,7 +49,7 @@
     },
     "apps/mcp-server": {
       "name": "@ograf-editor/mcp-server",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -145,7 +144,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -163,7 +161,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -181,7 +178,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -199,7 +195,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -217,7 +212,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -235,7 +229,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -253,7 +246,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -271,7 +263,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -289,7 +280,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -307,7 +297,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -325,7 +314,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -343,7 +331,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -361,7 +348,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -379,7 +365,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -397,7 +382,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -415,7 +399,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -433,7 +416,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -451,7 +433,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -469,7 +450,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -487,7 +467,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -505,7 +484,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -523,7 +501,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -541,7 +518,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -559,7 +535,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -577,7 +552,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -604,9 +578,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
-      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1479,16 +1453,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
-      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -1497,13 +1471,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
-      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.10",
+        "@vitest/spy": "4.1.11",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -1524,9 +1498,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
-      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1537,13 +1511,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
-      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.10",
+        "@vitest/utils": "4.1.11",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1551,14 +1525,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
-      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -1567,9 +1541,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
-      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1577,13 +1551,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
-      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.10",
+        "@vitest/pretty-format": "4.1.11",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2307,9 +2281,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.13.2",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.2.tgz",
-      "integrity": "sha512-JydRilDRkYBQMt9qR9U92mXxmbGqsqSn/IKOrh4e7/gEbn+0zSr8igTu0obwJoNGN4sez28DIql7FBHWydoJpA==",
+      "version": "4.13.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.7.tgz",
+      "integrity": "sha512-c8/gF9ac8Y78/agExVocyLevgR+JlpNB444Py0FSX8pJoPdYUfUzRcXtYEYGwt6l19qIlVZPN5Mfsw9jFShmQQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3733,19 +3707,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
-      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.10",
-        "@vitest/mocker": "4.1.10",
-        "@vitest/pretty-format": "4.1.10",
-        "@vitest/runner": "4.1.10",
-        "@vitest/snapshot": "4.1.10",
-        "@vitest/spy": "4.1.10",
-        "@vitest/utils": "4.1.10",
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -3773,12 +3747,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.10",
-        "@vitest/browser-preview": "4.1.10",
-        "@vitest/browser-webdriverio": "4.1.10",
-        "@vitest/coverage-istanbul": "4.1.10",
-        "@vitest/coverage-v8": "4.1.10",
-        "@vitest/ui": "4.1.10",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zd-ograf-editor",
   "private": true,
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "workspaces": [

--- a/scripts/buildStandalone.mjs
+++ b/scripts/buildStandalone.mjs
@@ -21,7 +21,7 @@ const outputParts = parse(outfile);
 const stagedOutfile = resolve(outputParts.dir, `${outputParts.name}.next${outputParts.ext}`);
 const previousOutfile = resolve(outputParts.dir, `${outputParts.name}.previous${outputParts.ext}`);
 const generatedEntrypoint = resolve(repositoryRoot, 'release/standalone-entry.ts');
-const version = process.env.OGRAF_STUDIO_BUILD_VERSION ?? '0.16.0.0';
+const version = process.env.OGRAF_STUDIO_BUILD_VERSION ?? '0.17.0.0';
 
 await mkdir(dirname(outfile), { recursive: true });
 await rm(stagedOutfile, { force: true });

--- a/scripts/smokeStandaloneLinux.sh
+++ b/scripts/smokeStandaloneLinux.sh
@@ -30,7 +30,7 @@ until curl -fsS "http://127.0.0.1:$port/health" >"$temporary_root/health.json"; 
 done
 
 curl -fsS "http://127.0.0.1:$port/" | grep -q '<title>OGraf Studio</title>'
-grep -q 'OGraf Studio 0.16 standalone server' "$temporary_root/server.log"
+grep -q 'OGraf Studio 0.17 standalone server' "$temporary_root/server.log"
 grep -q 'https://github.com/zerodensity/ograf-studio' "$temporary_root/server.log"
 cat "$temporary_root/health.json"
 printf '\nLinux standalone smoke test passed.\n'

--- a/scripts/verifyStandaloneArtifacts.mjs
+++ b/scripts/verifyStandaloneArtifacts.mjs
@@ -47,7 +47,7 @@ for (const artifact of artifacts) {
   }
   for (const embeddedText of [
     'OGraf Studio',
-    '0.16',
+    '0.17',
     'standalone server',
     'https://github.com/zerodensity/ograf-studio',
     '<!doctype html>',


### PR DESCRIPTION
Release OGraf Studio 0.17 with official OGraf wordmarks and website icons. Update package, standalone and MCP version metadata, generated contracts and concise public release notes. Refresh Hono and Vitest dependencies to resolve the reported advisories.

Validation: clean npm ci and npm run verify passed (548 tests); npm audit reports zero vulnerabilities. GitHub CI passed: https://github.com/zerodensity/ograf-studio/actions/runs/34345087678

Single-file release artifacts are built and checked separately before publication.
